### PR TITLE
Add documentation

### DIFF
--- a/docs/source/en/model_doc/mot.md
+++ b/docs/source/en/model_doc/mot.md
@@ -63,6 +63,11 @@ The original code can be found [here](https://github.com/llm-random/llm-random/b
 [[autodoc]] MoTModel
     - forward
 
+## MoTMLP
+
+[[autodoc]] MoTMLP
+    - forward
+
 ## MoTLMHeadModel
 
 [[autodoc]] MoTLMHeadModel

--- a/src/transformers/models/mot/modeling_mot.py
+++ b/src/transformers/models/mot/modeling_mot.py
@@ -364,6 +364,10 @@ class MoTAttention(nn.Module):
 
 
 class MoTMLP(nn.Module):
+    r"""
+    Implementation of the Mixture of Tokens Sparse MLP module.
+    """
+
     def __init__(self, inner_dim: int, config: MoTConfig, sparsity_dim: int = 0, init_type: str = "kaiming_uniform"):
         super().__init__()
 


### PR DESCRIPTION
The added docstring is quite short but it's consistent with docstrings added to other MLP modules, like:
r"""
Implementation of the Mixture of Tokens Sparse MLP module.
"""

r"""
Implementation of the NLLB-MoE sparse MLP module.
"""